### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ GRV depends on the following libraries:
 To install GRV run:
 
 ```
-go get -d https://github.com/rgburke/grv/cmd/grv
+go get -d github.com/rgburke/grv/cmd/grv
 cd $GOPATH/src/github.com/rgburke/grv
 make install
 ```


### PR DESCRIPTION
You shouldn't add a protocol to `go get`:

	[~]% go get -d https://github.com/rgburke/grv/cmd/grv
	package https:/github.com/rgburke/grv/cmd/grv: "https://" not allowed in import path