### PR TITLE
git2go.v26 to match latest libgit2 0.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ chmod +x ./grv
 ./grv -repoFilePath /path/to/repo
 ```
 
+## macOS
+
+```
+brew install libgit2 ncurses readline
+go get gopkg.in/rgburke/grv.git2go-v26/cmd/grv
+```
+
+
+
 ## Build instructions
 
 Go version 1.5 or later is required. GRV depends on the following libraries:

--- a/cmd/grv/commit_filter_test.go
+++ b/cmd/grv/commit_filter_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	git "gopkg.in/libgit2/git2go.v25"
+	git "gopkg.in/libgit2/git2go.v26"
 )
 
 func TestCommitFieldExistence(t *testing.T) {

--- a/cmd/grv/repo_data_loader.go
+++ b/cmd/grv/repo_data_loader.go
@@ -9,7 +9,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	slice "github.com/bradfitz/slice"
-	git "gopkg.in/libgit2/git2go.v25"
+	git "gopkg.in/libgit2/git2go.v26"
 )
 
 const (


### PR DESCRIPTION
Upgrade to git2go.v26 to match the latest libgit2 0.26.
On macOS,  Homebrew ships  libgit2 0.26 which makes installation as easy as
```
brew install libgit2 ncurses readline
go get gopkg.in/rgburke/grv.git2go-v26/cmd/grv
```

An example for #33 