### PR TITLE
Allow filtering of commits by full commit message

### DIFF
--- a/cmd/grv/commit_filter.go
+++ b/cmd/grv/commit_filter.go
@@ -112,6 +112,12 @@ var commitFields = map[string]CommitField{
 			return commit.commit.Summary()
 		},
 	},
+	"message": {
+		fieldType: FtString,
+		value: func(commit *Commit) interface{} {
+			return commit.commit.Message()
+		},
+	},
 	"parentcount": {
 		fieldType: FtNumber,
 		value: func(commit *Commit) interface{} {

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -543,6 +543,7 @@ The list of (case-insensitive) fields that can be used in the Commit View is:
  id             | string
  parentcount    | number
  summary        | string
+ message        | string
 ```
 
 The list of (case-insensitive) fields that can be used in the Ref View is:


### PR DESCRIPTION
This is useful for me, because the full message contains bug numbers, etc in the project I'm working on, so filtering the full message is something I do often. Let me know if this needs additional work :)

Cheers and thanks for the nice project!

PS: Forgot to add a test, will do so later